### PR TITLE
Scrolling

### DIFF
--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -20,7 +20,22 @@ class Interface:
         return interface.run()
 
     def __init__(self, stdscr) -> None:
-        self.stdscr = stdscr
+        # Create curses screen
+        stdscr.keypad(True)
+        curses.use_default_colors()
+        curses.noecho()
+        stdscr.refresh()
+
+        # Get screen width/height
+        self.height, self.width = stdscr.getmaxyx()
+
+        # Create a curses pad (pad size is height + 10)
+        mypad_height = 32767
+        
+        self.pos = 0
+        self.max_rows = 32767
+        self.stdscr = curses.newpad(mypad_height, self.width)
+
         curses.noecho()
         init_colors()
         self.stdscr.keypad(True)
@@ -31,8 +46,13 @@ class Interface:
         self.curr_tab = TABS[0]
         self.print_tabs()
         self.print_current_tab()
-        self.stdscr.refresh()
+        self.refresh()
 
+    #Allows us to use a Pad as if it were a Window by always maintaining the same height and width
+    #Call this instead of self.stdscr.refresh()
+    def refresh(self):
+        self.stdscr.refresh(self.pos + 2, 0, 0, 0, self.height - 1, self.width - 1)
+        
     def run(self):
         c = self.stdscr.getkey()
         while(c != 'q'):
@@ -44,7 +64,7 @@ class Interface:
 
             self.print_tabs()
             self.print_current_tab()
-            self.stdscr.refresh()
+            self.refresh()
 
             c = self.stdscr.getkey()
     
@@ -67,6 +87,14 @@ class Interface:
             row += len(tab) + 5
     
     def handle_key(self, c: str) -> None:
+        #Handle scrolling
+        if c == 'KEY_DOWN' and self.pos < self.stdscr.getyx()[0] - self.height - 1:
+            self.pos += 1
+            self.refresh()
+        elif c == 'KEY_UP' and self.pos > -2:
+            self.pos -= 1
+            self.refresh()
+
         if(c == 'KEY_LEFT'):
             self.curr_tab = TABS[TABS.index(self.curr_tab) - 1]
 
@@ -86,6 +114,7 @@ def print_section(section_name: str, return_lines: List[str], stdscr, row: int, 
         color_pair = 1
         if "Error" in line:
             color_pair = 2
+        stdscr.scrollok(1)
         stdscr.addstr(row, column, line, curses.color_pair(color_pair))
         row += 1
     row += 1
@@ -93,5 +122,4 @@ def print_section(section_name: str, return_lines: List[str], stdscr, row: int, 
 
 if __name__ == "__main__":
     curses.wrapper(Interface.start)
-
 

--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -91,7 +91,7 @@ class Interface:
         if c == 'KEY_DOWN' and self.pos < self.stdscr.getyx()[0] - self.height - 1:
             self.pos += 1
             self.refresh()
-        elif c == 'KEY_UP' and self.pos > -2:
+        elif c == 'KEY_UP' and self.pos > 0:
             self.pos -= 1
             self.refresh()
 

--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -63,7 +63,6 @@ class Interface:
             self.handle_key(c)
 
             self.print_tabs()
-            self.refresh()
             self.print_current_tab()
             self.refresh()
             try:

--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -51,8 +51,7 @@ class Interface:
     #Allows us to use a Pad as if it were a Window by always maintaining the same height and width
     #Call this instead of self.stdscr.refresh()
     def refresh(self):
-        height, width = self.stdscr.getyx()
-        self.stdscr.refresh(self.pos + 2, 0, 0, 0, height - 1, width - 1)
+        self.stdscr.refresh(self.pos + 2, 0, 0, 0, self.height - 1, self.width - 1)
         
     def run(self):
         c = self.stdscr.getkey()
@@ -64,6 +63,7 @@ class Interface:
             self.handle_key(c)
 
             self.print_tabs()
+            self.refresh()
             self.print_current_tab()
             self.refresh()
             try:
@@ -93,10 +93,8 @@ class Interface:
         #Handle scrolling
         if c == 'KEY_DOWN' and self.pos < self.stdscr.getyx()[0] - self.height - 1:
             self.pos += 1
-            self.refresh()
         elif c == 'KEY_UP' and self.pos > 0:
             self.pos -= 1
-            self.refresh()
 
         if(c == 'KEY_LEFT'):
             self.curr_tab = TABS[TABS.index(self.curr_tab) - 1]

--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -51,7 +51,8 @@ class Interface:
     #Allows us to use a Pad as if it were a Window by always maintaining the same height and width
     #Call this instead of self.stdscr.refresh()
     def refresh(self):
-        self.stdscr.refresh(self.pos + 2, 0, 0, 0, self.height - 1, self.width - 1)
+        height, width = self.stdscr.getyx()
+        self.stdscr.refresh(self.pos + 2, 0, 0, 0, height - 1, width - 1)
         
     def run(self):
         c = self.stdscr.getkey()
@@ -65,8 +66,10 @@ class Interface:
             self.print_tabs()
             self.print_current_tab()
             self.refresh()
-
-            c = self.stdscr.getkey()
+            try:
+                c = self.stdscr.getkey()
+            except:
+                c = "NO_INPUT"
     
     def print_current_tab(self):
         if self.curr_tab == "config":

--- a/dashboard/peers.py
+++ b/dashboard/peers.py
@@ -120,13 +120,17 @@ def format_row(column_widths, entries):
 
 def format_response_for_display(response: dict[str, any]) -> List[str]:
     if(response == None or response['result']['peers'] == None):
-        return ['Currently no peers are connected.']
+        formatted_lines = ['Currently no peers are connected.']
+        return formatted_lines
     else:
         peers = response['result']['peers']
         formatted_lines: List[str] = []
 
         formatted_lines.append(f"Total peers: {len(peers)}")
         formatted_lines.append("")
+
+        for i in range(20):
+            formatted_lines.append("")
 
         column_widths = [40, 80, 120]
         header = ['name/ip address', 'status', 'completed ledgers']

--- a/dashboard/peers.py
+++ b/dashboard/peers.py
@@ -120,8 +120,7 @@ def format_row(column_widths, entries):
 
 def format_response_for_display(response: dict[str, any]) -> List[str]:
     if(response == None or response['result']['peers'] == None):
-        formatted_lines = ['Currently no peers are connected.']
-        return formatted_lines
+        return ['Currently no peers are connected.']
     else:
         peers = response['result']['peers']
         formatted_lines: List[str] = []

--- a/dashboard/peers.py
+++ b/dashboard/peers.py
@@ -129,9 +129,6 @@ def format_response_for_display(response: dict[str, any]) -> List[str]:
         formatted_lines.append(f"Total peers: {len(peers)}")
         formatted_lines.append("")
 
-        for i in range(20):
-            formatted_lines.append("")
-
         column_widths = [40, 80, 120]
         header = ['name/ip address', 'status', 'completed ledgers']
         formatted_lines.append(format_row(column_widths, header))


### PR DESCRIPTION
## High Level Overview of Change

Adds vertical scrolling for when there's too much info vertically on the page

Note: You should now use `self.refresh()` instead of `self.stdscr.refresh()` -> This is since the underlying structure was changed from a `Window` to a `Pad` (Which is basically a window with no size limits that you can 'snap a picture' of at any position). So the refresh method needs to specify a location to view from, which `self.refresh` handles.

Also note that this PR builds off of #5 